### PR TITLE
Patch expose flag

### DIFF
--- a/compliance/inc/sys.php
+++ b/compliance/inc/sys.php
@@ -15,6 +15,7 @@ function compliance_update_op_behavior() {
 	
 		if(isset($_POST['compliance_cust_toggle'])) yourls_update_option( 'compliance_cust_toggle', $_POST['compliance_cust_toggle'] );
 		if(isset($_POST['compliance_intercept'])) yourls_update_option( 'compliance_intercept', $_POST['compliance_intercept'] );
+		if(isset($_POST['compliance_expose_flags'])) yourls_update_option( 'compliance_expose_flags', $_POST['compliance_expose_flags'] );
 	}
 }
 
@@ -51,20 +52,25 @@ function compliance_flag_list_mgr() {
 	}
 }
 
-// Mark flagged links on admin page
+// Mark flagged links on admin page - todo, add unflag option & link to flaglist
 yourls_add_filter( 'table_add_row', 'show_flagged_tablerow' );
 function show_flagged_tablerow($row, $keyword, $url, $title, $ip, $clicks, $timestamp) {
-	// If the row is malware, make the URL show in red;
-	$WEBPATH=substr(dirname(__FILE__), strlen(YOURLS_ABSPATH));
-	$flagset = check_flagpage($url, $keyword);
-	if($flagset !== false) {
-		$old_key = '/td class="keyword"/';
-		$new_key = 'td class="keyword" style="border-left: 6px solid red;"';
-		$newrow = preg_replace($old_key, $new_key, $row);
+
+	// Check if this is wanted
+	$compliance_expose_flags = yourls_get_option( 'compliance_expose_flags' ); 
+	if($compliance_expose_flags !== "false") {
+
+		// If the row is malware, make the URL show in red;
+		$WEBPATH=substr(dirname(__FILE__), strlen(YOURLS_ABSPATH));
+		$flagset = check_flagpage($url, $keyword);
+		if($flagset !== false) {
+			$old_key = '/td class="keyword"/';
+			$new_key = 'td class="keyword" style="border-left: 6px solid red;"';
+			$newrow = preg_replace($old_key, $new_key, $row);
+		} 
 	} else {
-		$newrow = $row;
+	$newrow = $row;
 	}
-	
 	return $newrow;
 }
 

--- a/compliance/plugin.php
+++ b/compliance/plugin.php
@@ -28,25 +28,29 @@ function compliance_do_page() {
 
 	// CHECK if the BEHAVIOR form was submitted
 	compliance_update_op_behavior();
-
+	
+	// Retreive BEHAVIOR settings & Set Values
 	$compliance_nuke = yourls_get_option( 'compliance_nuke' );
-
-	if ($compliance_nuke == "false" || $compliance_nuke == null) {
+	if ($compliance_nuke !== "true") {
 		$nuke_chk = null;
 		$vis_del = 'inline';
-		}
-	if ($compliance_nuke == "true") {
+		} else {
 		$nuke_chk = 'checked';
 		$vis_del = 'none';
 		}
 
-	$compliance_cust_toggle = yourls_get_option( 'compliance_cust_toggle' );
+	$compliance_expose_flags = yourls_get_option( 'compliance_expose_flags' ); 
+	if ($compliance_expose_flags !== "false") {
+		$exp_chk = 'checked';
+		} else {
+		$exp_chk = null;
+		}
 
-	if ($compliance_cust_toggle == "false" || $compliance_cust_toggle == null) {
+	$compliance_cust_toggle = yourls_get_option( 'compliance_cust_toggle' );
+	if ($compliance_cust_toggle !== "true") {
 		$url_chk = null;
 		$vis_url = 'none';
-		}
-	if ($compliance_cust_toggle == "true") {
+		} else {
 		$url_chk = 'checked';
 		$vis_url = 'inline';
 		}
@@ -109,9 +113,20 @@ function compliance_do_page() {
 						  </label>
 						</div>
 
+						<h3>Override Defaut: Admin Interface Expose Flags</h3>
+
+						<p>Compliance can check links on the fly and tag flagged links in your admin interface regardless of weather they are going to be nuked on the next redirect or not. If you are serving a large amount of short URL's and you notice big hangs when you open your admin interface you may want to disable this feature.</p>
+
+						<div class="checkbox">
+						  <label>
+							<input name="compliance_expose_flags" type="hidden" value="false" />
+							<input name="compliance_expose_flags" type="checkbox" value="true" $exp_chk > Expose flags on Admin Interface?
+						  </label>
+						</div>
+
 						<div style="display:$vis_del;">
 
-					<h3>Override Default: Intercept Page</h3>
+							<h3>Override Default: Intercept Page</h3>
 
 							<p>Compliance provides a well formed and functional Notice, or warning page written in bootstrap. You can opt to use your own, however.</p>
 
@@ -166,7 +181,7 @@ function compliance_do_page() {
 						<input type="hidden" name="nonce" value="$nonce" />
 						<p><input type="submit" value="FLUSH!" /></p>
 					</form>
-					<p>Don't forget to return here after submitting to check for errors!</p>
+					<p>Don't forget to return here after submitting to check for messages!</p>
 				</div>
 
 				<div  id="stat_tab_flag_list" class="tab">


### PR DESCRIPTION
This update puts an option in the Compliance plugin management page that allows the user to toggle weather or not flags are exposed in the admin interface, making it easier on the sql queries called on that particular page load.